### PR TITLE
重新封装接口：1）在endValuePack前可乱序put类型；2）自动判断处理器字节序，可适应更多单片机，如STC8H8K64；3）解耦…

### DIFF
--- a/Common/ble_pack.c
+++ b/Common/ble_pack.c
@@ -1,0 +1,236 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "ble_value.h"
+
+// 缓存数组
+static uint8_t buffer[PACK_SEND_SIZE_MAX];
+static uint8_t bits[PACK_SEND_BIT_MAX];
+static uint8_t bytes[PACK_SEND_BYTE_MAX];
+static int16_t i16s[PACK_SEND_I16_MAX];
+static int32_t i32s[PACK_SEND_I32_MAX];
+static float f32s[PACK_SEND_F32_MAX];
+
+// 检测处理器字节序
+emEndian checkEndian(void) {
+    uint16_t check = ENDIAN_CHECK;
+    return (emEndian)(((uint8_t *)(&check))[0]);
+}
+
+// 数据打包之前的准备工作，初始化数组
+emStat startValuePack(stPack *pack) {
+    // 检测参数合法性
+    if (pack == NULL || PACK_SEND_SIZE_MAX < 3) {
+        // TODO: 打印 warning 信息
+#ifdef DEBUG
+        printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+        return STAT_ERR;
+    }
+    memset(&buffer, 0, sizeof(buffer));
+    memset(&bits, 0, sizeof(bits));
+    memset(&bytes, 0, sizeof(bytes));
+    memset(&i16s, 0, sizeof(i16s));
+    memset(&i32s, 0, sizeof(i32s));
+    memset(&f32s, 0, sizeof(f32s));
+    // 初始化打包参数
+    pack->buffer = buffer;
+    memset(&pack->datas, 0, sizeof(pack->datas));
+    pack->datas.bits = bits;
+    pack->datas.bytes = bytes;
+    pack->datas.i16s = i16s;
+    pack->datas.i32s = i32s;
+    pack->datas.f32s = f32s;
+    pack->endian = checkEndian();
+    pack->index = 0;
+    pack->buffer[pack->index++] = PACK_HEAD;
+    pack->is_start = 1;
+    return STAT_OK;
+}
+
+// 避免覆盖 bit 字节
+#define CHECK_OFFSET()     \
+    if (bit_offset != 0) { \
+        pack->index++;     \
+        bit_offset = 0;    \
+    }
+// 根据传入的类型大小，分大小端填充 data 到 buffer
+#define FOR_PACK(PTR)                                                 \
+    do {                                                              \
+        paddr = (uint8_t *)(PTR);                                     \
+        sizeV = (uint8_t)sizeof(*(PTR));                              \
+        if (pack->index + sizeV >= PACK_SEND_SIZE_MAX) {              \
+            return STAT_ERR;                                          \
+        }                                                             \
+        for (ind = 0; ind < sizeV; ++ind) {                           \
+            if (ENDIAN_LITTLE == pack->endian) {                      \
+                pack->buffer[pack->index++] = paddr[ind];             \
+            } else {                                                  \
+                pack->buffer[pack->index++] = paddr[sizeV - ind - 1]; \
+            }                                                         \
+        }                                                             \
+    } while (0)
+// 将 data 转化为可发送的 buffer
+static emStat packValue(stPack *pack) {
+    // bit 类型位偏移量
+    uint16_t bit_offset = 0;
+    emType i;
+    uint16_t n;
+    uint8_t *paddr;
+    uint8_t sizeV;
+    uint8_t ind;
+    // 检测参数合法性
+    if (pack == NULL || pack->is_start != 1) {
+        // TODO: 打印 warning 信息
+#ifdef DEBUG
+        printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+        return STAT_ERR;
+    }
+    // 按顺序打包数据
+    for (i = TYPE_BIT; i < TYPE_MAX; ++i) {
+        for (n = 0; n < pack->datas.nums[i]; ++n) {
+            switch (i) {
+                case TYPE_BIT: {
+                    if (pack->datas.bits[n]) {
+                        pack->buffer[pack->index] |= 0x01 << bit_offset;
+                    } else {
+                        pack->buffer[pack->index] &= ~(0x01 << bit_offset);
+                    }
+                    bit_offset++;
+                    if (bit_offset >= 8) {
+                        bit_offset = 0;
+                        if (pack->index + 1 >= PACK_SEND_SIZE_MAX) {
+#ifdef DEBUG
+                            printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+                            return STAT_ERR;
+                        }
+                        pack->index++;
+                    }
+                } break;
+                case TYPE_BYTE: {
+                    CHECK_OFFSET();
+                    FOR_PACK(pack->datas.bytes + n);
+                } break;
+                case TYPE_I16: {
+                    CHECK_OFFSET();
+                    FOR_PACK(pack->datas.i16s + n);
+                } break;
+                case TYPE_I32: {
+                    CHECK_OFFSET();
+                    FOR_PACK(pack->datas.i32s + n);
+                } break;
+                case TYPE_F32: {
+                    CHECK_OFFSET();
+                    FOR_PACK(pack->datas.f32s + n);
+                } break;
+                default: {
+#ifdef DEBUG
+                    printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+                    return STAT_ERR;
+                }
+            }
+        }
+    }
+    return STAT_OK;
+}
+#undef CHECK_OFFSET
+#undef FOR_PACK
+
+// 结束打包流程，将数据转化为可发送的 buffer
+emStat endValuePack(stPack *pack) {
+    uint8_t sum = 0;
+    uint16_t i;
+    // 检测参数合法性
+    if (pack == NULL || pack->is_start != 1) {
+        // TODO: 打印 warning 信息
+#ifdef DEBUG
+        printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+        return STAT_ERR;
+    }
+    // 将 datas 内数据填充到 buffer 内
+    if (STAT_OK == packValue(pack)) {
+        if (pack->index + 2 >= PACK_SEND_SIZE_MAX) {
+#ifdef DEBUG
+            printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+            return STAT_ERR;
+        }
+        // 计算校验和
+        for (i = 1; i < pack->index; ++i) {
+            sum += pack->buffer[i];
+        }
+        pack->buffer[pack->index++] = sum;
+        pack->buffer[pack->index++] = PACK_TAIL;
+        pack->is_start = 0;
+        return STAT_OK;
+    } else {
+#ifdef DEBUG
+        printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+        return STAT_ERR;
+    }
+}
+
+emStat putBool(stPack *pack, uint8_t v) {
+    // 检测参数合法性
+    if (pack == NULL || pack->datas.nums[TYPE_BIT] >= PACK_SEND_BIT_MAX) {
+#ifdef DEBUG
+        printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+        return STAT_ERR;
+    }
+    pack->datas.bits[pack->datas.nums[TYPE_BIT]++] = v;
+    return STAT_OK;
+}
+
+emStat putByte(stPack *pack, uint8_t v) {
+    // 检测参数合法性
+    if (pack == NULL || pack->datas.nums[TYPE_BYTE] >= PACK_SEND_BYTE_MAX) {
+#ifdef DEBUG
+        printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+        return STAT_ERR;
+    }
+    pack->datas.bytes[pack->datas.nums[TYPE_BYTE]++] = v;
+    return STAT_OK;
+}
+
+emStat putShort(stPack *pack, int16_t v) {
+    // 检测参数合法性
+    if (pack == NULL || pack->datas.nums[TYPE_I16] >= PACK_SEND_I16_MAX) {
+#ifdef DEBUG
+        printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+        return STAT_ERR;
+    }
+    pack->datas.i16s[pack->datas.nums[TYPE_I16]++] = v;
+    return STAT_OK;
+}
+
+emStat putInt(stPack *pack, int32_t v) {
+    // 检测参数合法性
+    if (pack == NULL || pack->datas.nums[TYPE_I32] >= PACK_SEND_I32_MAX) {
+#ifdef DEBUG
+        printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+        return STAT_ERR;
+    }
+    pack->datas.i32s[pack->datas.nums[TYPE_I32]++] = v;
+    return STAT_OK;
+}
+
+emStat putFloat(stPack *pack, float v) {
+    // 检测参数合法性
+    if (pack == NULL || pack->datas.nums[TYPE_F32] >= PACK_SEND_F32_MAX) {
+#ifdef DEBUG
+        printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+        return STAT_ERR;
+    }
+    pack->datas.f32s[pack->datas.nums[TYPE_F32]++] = v;
+    return STAT_OK;
+}

--- a/Common/ble_unpack.c
+++ b/Common/ble_unpack.c
@@ -1,0 +1,176 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "ble_value.h"
+
+// 缓存数组
+static uint8_t bits[PACK_RECEIVE_BIT_MAX];
+static uint8_t bytes[PACK_RECEIVE_BYTE_MAX];
+static int16_t i16s[PACK_RECEIVE_I16_MAX];
+static int32_t i32s[PACK_RECEIVE_I32_MAX];
+static float f32s[PACK_RECEIVE_F32_MAX];
+
+// 设置 buffer、size 及各类型数据个数
+emStat initValueUnpack(stPack *pack, uint8_t *buffer, uint16_t size_buff,
+                       uint16_t nbit, uint16_t nbyte, uint16_t ni16, uint16_t ni32, uint16_t nf32) {
+    // 检测参数合法性
+    if (pack == NULL || buffer == NULL ||
+        PACK_RECEIVE_SIZE_MAX < 3 ||
+        size_buff > PACK_RECEIVE_SIZE_MAX ||
+        nbit > PACK_RECEIVE_BIT_MAX ||
+        nbyte > PACK_RECEIVE_BYTE_MAX ||
+        ni16 > PACK_RECEIVE_I16_MAX ||
+        ni32 > PACK_RECEIVE_I32_MAX ||
+        nf32 > PACK_RECEIVE_F32_MAX) {
+        // TODO: 打印 warning 信息
+#ifdef DEBUG
+        printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+        return STAT_ERR;
+    }
+    memset(&bits, 0, sizeof(bits));
+    memset(&bytes, 0, sizeof(bytes));
+    memset(&i16s, 0, sizeof(i16s));
+    memset(&i32s, 0, sizeof(i32s));
+    memset(&f32s, 0, sizeof(f32s));
+    // 初始化解包参数
+    pack->datas.bits = bits;
+    pack->datas.bytes = bytes;
+    pack->datas.i16s = i16s;
+    pack->datas.i32s = i32s;
+    pack->datas.f32s = f32s;
+    pack->buffer = buffer;
+    pack->index = size_buff;
+    pack->datas.nums[TYPE_BIT] = nbit;
+    pack->datas.nums[TYPE_BYTE] = nbyte;
+    pack->datas.nums[TYPE_I16] = ni16;
+    pack->datas.nums[TYPE_I32] = ni32;
+    pack->datas.nums[TYPE_F32] = nf32;
+    pack->endian = checkEndian();
+    pack->is_start = 2;
+    return STAT_OK;
+}
+
+// 使用前检查数据边界
+#define CHECK_BUFFER()                               \
+    if (pbuffer - pack->buffer >= pack->index - 2) { \
+        return STAT_ERR;                             \
+    }
+// 保证后续读取不出错
+#define CHECK_OFFSET()     \
+    if (bit_offset != 0) { \
+        pbuffer++;         \
+        bit_offset = 0;    \
+    }
+// 根据传入的类型大小，分大小端解 buffer 到 data
+#define FOR_UNPACK(PTR)                            \
+    do {                                           \
+        paddr = (uint8_t *)(PTR);                  \
+        sizeV = (uint8_t)sizeof(*(PTR));           \
+        for (ind = 0; ind < sizeV; ++ind) {        \
+            CHECK_BUFFER();                        \
+            if (ENDIAN_LITTLE == pack->endian) {   \
+                paddr[ind] = *pbuffer;             \
+            } else {                               \
+                paddr[sizeV - ind - 1] = *pbuffer; \
+            }                                      \
+            pbuffer++;                             \
+        }                                          \
+    } while (0)
+// 将 buffer 解析为 datas
+static emStat unpackBuffer(stPack *pack) {
+    // bit 类型位偏移量
+    uint16_t bit_offset = 0;
+    uint8_t *pbuffer = pack->buffer + 1;
+    emType i;
+    uint16_t n;
+    uint8_t *paddr;
+    uint8_t sizeV;
+    uint8_t ind;
+    // 检测参数合法性
+    if (pack == NULL || pack->is_start != 2) {
+        // TODO: 打印 warning 信息
+#ifdef DEBUG
+        printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+        return STAT_ERR;
+    }
+    // 按顺序打包数据
+    for (i = TYPE_BIT; i < TYPE_MAX; ++i) {
+        for (n = 0; n < pack->datas.nums[i]; ++n) {
+            switch (i) {
+                case TYPE_BIT: {
+                    CHECK_BUFFER();
+                    pack->datas.bits[n] = ((*pbuffer) >> bit_offset) & 0x01;
+                    bit_offset++;
+                    if (bit_offset >= 8) {
+                        bit_offset = 0;
+                        pbuffer++;
+                    }
+                } break;
+                case TYPE_BYTE: {
+                    CHECK_OFFSET();
+                    FOR_UNPACK(pack->datas.bytes + n);
+                } break;
+                case TYPE_I16: {
+                    CHECK_OFFSET();
+                    FOR_UNPACK(pack->datas.i16s + n);
+                } break;
+                case TYPE_I32: {
+                    CHECK_OFFSET();
+                    FOR_UNPACK(pack->datas.i32s + n);
+                } break;
+                case TYPE_F32: {
+                    CHECK_OFFSET();
+                    FOR_UNPACK(pack->datas.f32s + n);
+                } break;
+                default: {
+#ifdef DEBUG
+                    printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+                    return STAT_ERR;
+                }
+            }
+        }
+    }
+    return STAT_OK;
+}
+#undef CHECK_BUFFER
+#undef CHECK_OFFSET
+#undef FOR_UNPACK
+
+// 解析接收到的 buffer 包
+emStat runValueUnpack(stPack *pack) {
+    uint8_t sum = 0;
+    uint16_t i;
+    // 检测参数合法性
+    if (pack == NULL || pack->is_start != 2) {
+        // TODO: 打印 warning 信息
+#ifdef DEBUG
+        printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+        return STAT_ERR;
+    }
+    // 检测包结构，检验校验和
+    for (i = 1; i < pack->index - 2; ++i) {
+        sum += pack->buffer[i];
+    }
+    if (pack->buffer[0] != PACK_HEAD ||
+        pack->buffer[pack->index - 1] != PACK_TAIL ||
+        sum != pack->buffer[pack->index - 2]) {
+#ifdef DEBUG
+        printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+        return STAT_ERR;
+    }
+    // 从 buffer 解出数据到 datas
+    if (STAT_OK == unpackBuffer(pack)) {
+        pack->is_start = 0;
+        return STAT_OK;
+    } else {
+#ifdef DEBUG
+        printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+#endif
+        return STAT_ERR;
+    }
+}

--- a/Common/ble_value.h
+++ b/Common/ble_value.h
@@ -1,0 +1,81 @@
+#ifndef __BLE_VALUE_H__
+#define __BLE_VALUE_H__
+
+#include <assert.h>
+#include <stdint.h>
+
+#define PACK_HEAD 0xA5
+#define PACK_TAIL 0x5A
+
+#define PACK_SEND_SIZE_MAX 256
+#define PACK_SEND_BIT_MAX 8
+#define PACK_SEND_BYTE_MAX 8
+#define PACK_SEND_I16_MAX 8
+#define PACK_SEND_I32_MAX 8
+#define PACK_SEND_F32_MAX 8
+
+#define PACK_RECEIVE_SIZE_MAX 256
+#define PACK_RECEIVE_BIT_MAX 8
+#define PACK_RECEIVE_BYTE_MAX 8
+#define PACK_RECEIVE_I16_MAX 8
+#define PACK_RECEIVE_I32_MAX 8
+#define PACK_RECEIVE_F32_MAX 8
+
+typedef enum {
+    STAT_OK = 0,
+    STAT_ERR = 1,
+} emStat;
+
+typedef enum {
+    ENDIAN_CHECK = 0x1234,
+    ENDIAN_BIG = 0x12,
+    ENDIAN_LITTLE = 0x34,
+} emEndian;
+
+typedef enum {
+    TYPE_BIT = 0,
+    TYPE_BYTE = 1,
+    TYPE_I16 = 2,
+    TYPE_I32 = 3,
+    TYPE_F32 = 4,
+    TYPE_MAX,
+} emType;
+
+typedef struct {
+    uint16_t nums[TYPE_MAX];
+    uint8_t *bits;
+    uint8_t *bytes;
+    int16_t *i16s;
+    int32_t *i32s;
+    float *f32s;
+} stData;
+
+typedef struct {
+    emEndian endian;
+    uint16_t index;
+    uint8_t *buffer;
+    uint8_t is_start;
+    stData datas;
+} stPack;
+
+emEndian checkEndian(void);
+
+emStat startValuePack(stPack *pack);
+emStat endValuePack(stPack *pack);
+emStat putBool(stPack *pack, uint8_t v);
+emStat putByte(stPack *pack, uint8_t v);
+emStat putShort(stPack *pack, int16_t v);
+emStat putInt(stPack *pack, int32_t v);
+emStat putFloat(stPack *pack, float v);
+
+emStat initValueUnpack(stPack *pack, uint8_t *buffer, uint16_t size_buff,
+                       uint16_t nbit, uint16_t nbyte, uint16_t ni16, uint16_t ni32, uint16_t nf32);
+emStat runValueUnpack(stPack *pack);
+
+#ifdef DEBUG
+#define CHECK_ERR(FUNC) assert(STAT_OK == (FUNC))
+#else
+#define CHECK_ERR(FUNC) FUNC
+#endif
+
+#endif

--- a/Common/test/main.c
+++ b/Common/test/main.c
@@ -1,0 +1,63 @@
+#include <stdint.h>
+#include <stdio.h>
+
+#include "ble_value.h"
+
+int main(int argc, char *argv[]) {
+    // 打包数据
+    stPack pack;
+    CHECK_ERR(startValuePack(&pack));
+    CHECK_ERR(putBool(&pack, 1));
+    CHECK_ERR(putBool(&pack, 1));
+    CHECK_ERR(putBool(&pack, 0));
+    CHECK_ERR(putBool(&pack, 1));
+    CHECK_ERR(putByte(&pack, 0x11));
+    CHECK_ERR(putByte(&pack, 0x83));
+    CHECK_ERR(putInt(&pack, 0x7856));
+    CHECK_ERR(putShort(&pack, 0x1234));
+    CHECK_ERR(putFloat(&pack, 3.14159));
+    CHECK_ERR(endValuePack(&pack));
+
+    for (int i = 0; i < pack.index; ++i) {
+        printf("0x%02x ", pack.buffer[i]);
+    }
+    putchar('\n');
+
+    // 解包数据
+    stPack unpack;
+    CHECK_ERR(initValueUnpack(&unpack, pack.buffer, pack.index,
+                              pack.datas.nums[TYPE_BIT],
+                              pack.datas.nums[TYPE_BYTE],
+                              pack.datas.nums[TYPE_I16],
+                              pack.datas.nums[TYPE_I32],
+                              pack.datas.nums[TYPE_F32]));
+    CHECK_ERR(runValueUnpack(&unpack));
+
+    for (emType i = TYPE_BIT; i < TYPE_MAX; ++i) {
+        for (uint16_t n = 0; n < unpack.datas.nums[i]; ++n) {
+            switch (i) {
+                case TYPE_BIT: {
+                    printf("%hhu, ", unpack.datas.bits[n]);
+                } break;
+                case TYPE_BYTE: {
+                    printf("%hhu(%#x), ", unpack.datas.bytes[n], unpack.datas.bytes[n]);
+                } break;
+                case TYPE_I16: {
+                    printf("%hd(%#x), ", unpack.datas.i16s[n], unpack.datas.i16s[n]);
+                } break;
+                case TYPE_I32: {
+                    printf("%d(%#x), ", unpack.datas.i32s[n], unpack.datas.i32s[n]);
+                } break;
+                case TYPE_F32: {
+                    printf("%f, ", unpack.datas.f32s[n]);
+                } break;
+                default: {
+                    printf("%s %s:%d\n", __func__, __FILE__, __LINE__);
+                }
+            }
+        }
+        putchar('\n');
+    }
+
+    return 0;
+}


### PR DESCRIPTION
重新封装接口：1）在endValuePack前可乱序put类型；2）自动判断处理器字节序，可适应更多单片机，如STC8H8K64；3）解耦解析接收缓存区接口